### PR TITLE
Split character list on commas, if there are any.

### DIFF
--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -335,9 +335,17 @@ class KanjiColorizer:
             characters = KanjiVG.get_all()
         else:
             characters = []
+            if ',' in self.settings.characters \
+                    and len(self.settings.characters) > 1:
+                self.settings.characters = self.settings.characters.split(',')
             for c in self.settings.characters:
+                var = ''
+                if '-' in c:
+                    varsplit = c.split('-')
+                    c = varsplit[0]
+                    var = '-'.join(varsplit[1:])
                 try:
-                    characters.append(KanjiVG(c))
+                    characters.append(KanjiVG(c, var))
                 except InvalidCharacterError:
                     pass
         for kanji in characters:


### PR DESCRIPTION
This is a cleaned-up re-commit of pull request #6, just the relevant, “live” code.

When the list provided with `--characters` contains a comma, split on that.
The point is that this way you can convert just a few characters with variants.

For example, i came along [冥-Kaisho](https://github.com/ospalh/kanjivg/commit/e3d36c20467e872f1c819edb6d7e6b69f8d2b5ff) and noticed that the strokes where wrong. To quickly get a colored version of your work in progress, it is nice to just create the single _variant_ character with, in this case, `./kanji_colorize.py --characters 冥-Kaisho,`
