### PR TITLE
Fix invalid write mode on adding SVG to media

### DIFF
--- a/anki/kanji_colorizer.py
+++ b/anki/kanji_colorizer.py
@@ -83,8 +83,6 @@ from aqt.utils import showInfo, askUser
 from aqt.qt import *
 from kanjicolorizer.colorizer import (KanjiVG, KanjiColorizer,
                                       InvalidCharacterError)
-import os
-from codecs import open
 import string
 
 srcField = 'Kanji'
@@ -143,17 +141,9 @@ def addKanji(note, flag=False, currentFieldIndex=None):
         except InvalidCharacterError:
             # silently ignore non-Japanese characters
             continue
-        try:
-            with open(filename,'w', encoding='utf-8') as file:
-                file.write(kc.get_colored_svg(character))
-                mw.col.media.addFile(os.path.abspath(unicode(filename)))
-                dst+=u'<img src="%s">' % filename
-        except IOError as e:
-            if e.errno == FILE_NOT_FOUND:
-                print "file not found: "+filename+". Ignoring ..."
-            else:
-                raise
-
+        char_svg = kc.get_colored_svg(character).encode('utf_8')
+        anki_fname = mw.col.media.writeData(unicode(filename, 'utf_8'), char_svg)
+        dst += '<img src="{!s}">'.format(anki_fname).encode('utf_8')
 
     note[dstField] = dst
     note.flush()


### PR DESCRIPTION
OS: Mircosoft Windows 7 Home Premium SP1
Anki version: Version 2.0.33
kanji-colorizer version: Updated 2014-10-12 ([via Ankiweb](https://ankiweb.net/shared/info/1964372878))

Steps to Reproduce:

1. Open AnkiSRS
2. Click `Browse`
3. Ensure there are enough cards visible to cause the scrollbar to appear (resizing the `Browse` window may also work)
4. Find and select a card from the list that is set up to be used with the `kanji_colorizer` addon
5. Click on the `Kanji` field.  Ensure the mouse cursor is visible in this field.
6. Scroll the mouse wheel up and down a few times on the card list to cause the `Kanji` field to lose focus
7. Note raised error message.  Error message may be slightly delayed, so wait ~20 seconds before repeating step 6.

The intial error message was as follows:

```python
An error occurred in an add-on.
Please post on the add-on forum:
https://anki.tenderapp.com/discussions/add-ons

Traceback (most recent call last):
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/aqt.webview", line 18, in run
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/aqt.editor", line 462, in bridge
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/anki.hooks", line 32, in runFilter
  File "M:\Dropbox\Anki\addons\kanji_colorizer.py", line 166, in onFocusLost
    return addKanji(note, flag, currentFieldIndex)
  File "M:\Dropbox\Personal\Anki\addons\kanji_colorizer.py", line 152, in addKanji
    if e.errno == FILE_NOT_FOUND:
NameError: global name 'FILE_NOT_FOUND' is not defined
```

Based on [colorizer.py](https://github.com/cayennes/kanji-colorize/blob/a6c3783e62b46e187afecbb95e96b63f79756e64/kanjicolorizer/colorizer.py#L33), it looks like this was just a missing import statement.  My fix ended up removing the relevant line anyways, so it's neither here nor there.

However, `NameError: global name 'FILE_NOT_FOUND' is not defined` was masking the actual issue.  The actual error message is as follows:

```python
An error occurred in an add-on.
Please post on the add-on forum:
https://anki.tenderapp.com/discussions/add-ons

Traceback (most recent call last):
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/aqt.webview", line 18, in run
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/aqt.editor", line 462, in bridge
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/anki.hooks", line 32, in runFilter
  File "M:\Dropbox\Anki\addons\kanji_colorizer.py", line 167, in onFocusLost
    return addKanji(note, flag, currentFieldIndex)
  File "M:\Dropbox\Anki\addons\kanji_colorizer.py", line 148, in addKanji
    with open(filename,'w', encoding='utf-8') as file:
  File "C:\cygwin\home\dae\win\build\pyi.win32\anki\outPYZ1.pyz/codecs", line 881, in open
IOError: [Errno 22] invalid mode ('wb') or filename: '0884c.svg'
```

I'm not actually entirely sure as to the root cause of this issue.  Anki's documentation for the plugin API is lacking, so I've had to work off of the source.

As far as I can tell, there's an issue with encoding between the source SVGs and how data is being written to Anki's media folder.  I have yet to test this on platforms other than Windows, so it could very well be platform-specific.  I'm not _entirely_ clear on all of the instances where this error may appear, as there didn't seem to be any issues in adding the SVGs to Anki's media folder initially.  That is, SVG files for characters added to a deck are appearing in the media folder as expected, but this error is still being thrown.

Instead of constructing a `file` object and using `mw.col.media.addFile()` on the in-memory instance, we should write the data directly with [`mw.col.media.writeData()`](https://github.com/dae/anki/blob/08829da01109b4916125a5b4a9efeae3ee90c4eb/anki/media.py#L140) and let Anki handle the necessary file operations.  This also has the side effect of returning the filename Anki used to save the file [after its own processing](https://github.com/dae/anki/blob/08829da01109b4916125a5b4a9efeae3ee90c4eb/anki/media.py#L145-L147) rather than assuming that Anki will always use the same filename as is returned by `KanjiVG().ascii_filename` (which is not guaranteed, due to the aforementioned processing).

Please let me know if you have any questions, if there are further tweaks you'd like me to make, or anything else.