### PR TITLE
Add option to generate diagrams only for notes with an empty diagram field

### DIFF
--- a/anki/kanji_colorizer.py
+++ b/anki/kanji_colorizer.py
@@ -178,7 +178,26 @@ def regenerate_all():
             addKanji(mw.col.getNote(nid))
     showInfo("Done regenerating colorized kanji diagrams!")
 
+def generate_for_new():
+    if not askUser("This option will generate diagrams for notes with "
+                   "an empty {} field only. "
+                   "Proceed?".format(dstField)):
+        return
+    model_ids = [mid for mid in mw.col.models.ids() if modelIsCorrectType(mw.col.models.get(mid))]
+    # Generate search string in the format 
+    #    (mid:123 or mid:456) Kanji:_* Diagram:
+    search_str = '({}) {}:_* {}:'.format(
+        ' or '.join(('mid:'+mid for mid in model_ids)), srcField, dstField)
+    # Find the notes
+    for note_id in mw.col.findNotes(search_str):
+        addKanji(mw.col.getNote(note_id))
+    showInfo("Done regenerating colorized kanji diagrams!")
+
 # add menu item
 do_regenerate_all = QAction("Kanji Colorizer: (re)generate all", mw)
 mw.connect(do_regenerate_all, SIGNAL("triggered()"), regenerate_all)
 mw.form.menuTools.addAction(do_regenerate_all)
+
+do_generate_new = QAction("Kanji Colorizer: generate all new", mw)
+do_generate_new.triggered.connect(generate_for_new)
+mw.form.menuTools.addAction(do_generate_new)


### PR DESCRIPTION
For me, it often happens that I add Anki notes using tools like yomichan or using AnkiDroid, where the diagrams are not generated. Then, on the PC, I can use the regenerate all function to generate the diagrams for those. However, when using a large amount of notes (such as with shared public big kanji decks), this might take a while. So I came up with writing a small extension that searches for notes that dont have a stroke order diagram yet and generates the diagrams only for those. This way, it's faster.