### PR TITLE
Anki: Add Config to Prevent Overwrite

### DIFF
--- a/anki/config.json
+++ b/anki/config.json
@@ -6,4 +6,5 @@
  "model":"japanese",
  "src-field":"Kanji",
  "dst-field":"Diagram",
- "diagrammed-characters":"auto"}
+ "diagrammed-characters":"auto",
+ "overwrite-dest": true}

--- a/anki/config.md
+++ b/anki/config.md
@@ -12,5 +12,6 @@
     * `all`: all characters
     * `kanji`: only kanji, not kana or anything else
     * `auto`: if there are some kanji and some other characters only include the kanji; otherwise include all characters
+* `overwrite-dest`: set to true by default. If false the destination field will not be overwritten if there is anything in it.
 
 Some changes will not take effect until you restart anki.

--- a/anki/kanji_colorizer.py
+++ b/anki/kanji_colorizer.py
@@ -63,6 +63,7 @@ config += str(addon_config["image-size"])
 modelNameSubstring = 'japanese'
 srcField           = 'Kanji'
 dstField           = 'Diagram'
+overwrite          = True
 
 # avoid errors due to invalid config
 if 'model' in addon_config and type(addon_config['model']) is str:
@@ -71,6 +72,8 @@ if 'src-field' in addon_config and type(addon_config['src-field']) is str:
     srcField = addon_config['src-field']
 if 'dst-field' in addon_config and type(addon_config['dst-field']) is str:
     dstField = addon_config['dst-field']
+if 'overwrite-dest' in addon_config and type(addon_config['overwrite-dest']) is bool:
+    overwrite = addon_config['overwrite-dest']
 
 kc = KanjiColorizer(config)
 
@@ -140,6 +143,9 @@ def addKanji(note, flag=False, currentFieldIndex=None):
         char_svg = kc.get_colored_svg(character).encode('utf_8')
         anki_fname = mw.col.media.writeData(filename, char_svg)
         dst += '<img src="{!s}">'.format(anki_fname)
+
+    if oldDst != '' and not overwrite:
+        return flag
 
     if dst != oldDst and dst != '':
         note[dstField] = dst


### PR DESCRIPTION
Adds `overwrite-dest` to config file. When `overwrite-dest` is set
to false the destination field will only be overwritten if it is
empty.

This allows for editing the dest field after kanji is generated
and not worry about it being replaced.

 #64