### PR TITLE
Add option to draw grid under characters

### DIFF
--- a/anki/config.json
+++ b/anki/config.json
@@ -7,4 +7,5 @@
  "src-field":"Kanji",
  "dst-field":"Diagram",
  "diagrammed-characters":"auto",
- "overwrite-dest": true}
+ "overwrite-dest": true,
+ "grid": "none"}

--- a/anki/config.md
+++ b/anki/config.md
@@ -13,5 +13,12 @@
     * `kanji`: only kanji, not kana or anything else
     * `auto`: if there are some kanji and some other characters only include the kanji; otherwise include all characters
 * `overwrite-dest`: set to true by default. If false the destination field will not be overwritten if there is anything in it.
+* `grid`: options to draw a grid (default: `none`):
+    * `none`: no grid
+    * `4`: a 2x2 grid
+    * `8`: a 4x4 grid
+    * `diag`: diagonals
+    * `diag4`: a 2x2 grid with diagonals
+    * `diag8`: a 4x4 grid with diagonals
 
 Some changes will not take effect until you restart anki.

--- a/anki/kanji_colorizer.py
+++ b/anki/kanji_colorizer.py
@@ -59,6 +59,8 @@ config += " --value "
 config += str(addon_config["value"])
 config += " --image-size "
 config += str(addon_config["image-size"])
+config += " --grid "
+config += addon_config["grid"]
 
 modelNameSubstring = 'japanese'
 srcField           = 'Kanji'

--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -283,6 +283,13 @@ class KanjiColorizer:
                         '(default: %(default)s)')
         self._parser.add_argument('-o', '--output-directory',
                     default='colorized-kanji')
+        self._parser.add_argument('--grid', default='none', type=str,
+                    choices=['none', '4', '8', 'diag', 'diag4', 'diag8'],
+                    help='none: no grid is drawn. 4: a 2x2 grid is drawn. '
+                        '8; a 4x4 grid is drawn. diag: diagonals are drawn. '
+                        'diag4: a 2x2 grid with diagonals is drawn. '
+                        'diag8: a 4x4 grid with diagonals is drawn. '
+                        '(default: ' '%(default)s)')
 
     # Public methods
 
@@ -566,6 +573,7 @@ settings:
     saturation: """ + str(self.settings.saturation) + """
     value: """ + str(self.settings.value) + """
     image_size: """ + str(self.settings.image_size) + """
+    grid: """ + str(self.settings.grid) + """
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -419,6 +419,9 @@ class KanjiColorizer:
         if self.settings.group_mode:
             svg = self._remove_strokes(svg)
 
+        if self.settings.grid != "none":
+            svg = self._add_grid(svg)
+
         svg = self._resize_svg(svg)
         svg = self._comment_copyright(svg)
         return svg
@@ -540,6 +543,44 @@ class KanjiColorizer:
 
                 nsvg+=line+"\n"
             return nsvg
+
+    def _add_grid(self, svg):
+        """
+        Add a grid to the svg, depending on the setting the program is run with.
+        The grid does not need rescaling.
+
+        >>> svg = '<svg  width="109" height="109" viewBox="0 0 109 109">'
+        >>> kc = KanjiColorizer('--grid 4')
+        >>> kc._add_grid(svg)
+        '<svg  width="109" height="109" viewBox="0 0 109 109">\n
+        <g id="kvg:grid" stroke="grey">\n
+        \t<path id="kvg:grid-4h" d="M0,163.5H327"/>\n
+        \t<path id="kvg:grid-4v" d="M163.5,0V327"/>\n
+        </g>'
+        >>> svg = '<svg  width="109" height="109" viewBox="0 0 109 109">'
+        >>> kc = KanjiColorizer('--grid diag --image-size 109')
+        >>> kc._add_grid(svg)
+        '<svg  width="109" height="109" viewBox="0 0 109 109">\n
+        <g id="kvg:grid" stroke="grey">\n
+        \t<path id="kvg:grid-d1" d="M0,0L109,109"/>\n'
+        \t<path id="kvg:grid-d1" d="M0,109L109,0"/>\n'
+        </g>'
+        """
+        grid = '\n<g id="kvg:grid" stroke="grey">\n'
+        if "4" in self.settings.grid or "8" in self.settings.grid:
+            grid = grid + '\t<path id="kvg:grid-4h" d="M0,' + str(self.settings.image_size/2) + 'H' + str(self.settings.image_size) + '"/>\n'
+            grid = grid + '\t<path id="kvg:grid-4v" d="M' + str(self.settings.image_size/2) + ',0V' + str(self.settings.image_size) + '"/>\n'
+        if "8" in self.settings.grid:
+            grid = grid + '\t<path id="kvg:grid-4h1" d="M0,' + str(self.settings.image_size/4) + 'H' + str(self.settings.image_size) + '"/>\n'
+            grid = grid + '\t<path id="kvg:grid-4h2" d="M0,' + str(self.settings.image_size*3/4) + 'H' + str(self.settings.image_size) + '"/>\n'
+            grid = grid + '\t<path id="kvg:grid-4v1" d="M' + str(self.settings.image_size/4) + ',0V' + str(self.settings.image_size) + '"/>\n'
+            grid = grid + '\t<path id="kvg:grid-4v2" d="M' + str(self.settings.image_size*3/4) + ',0V' + str(self.settings.image_size) + '"/>\n'
+        if "diag" in self.settings.grid:
+            grid = grid + '\t<path id="kvg:grid-d1" d="M0,0L' + str(self.settings.image_size) + ',' + str(self.settings.image_size) + '"/>\n'
+            grid = grid + '\t<path id="kvg:grid-d1" d="M0,' + str(self.settings.image_size) + 'L' + str(self.settings.image_size) + ',0"/>\n'
+        grid = grid + '</g>\n'
+        place_after = '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">'
+        return svg.replace(place_after, place_after + grid)
 
     def _comment_copyright(self, svg):
         """

--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -328,7 +328,7 @@ class KanjiColorizer:
         >>> svg.splitlines()[0]
         '<?xml version="1.0" encoding="UTF-8"?>'
         >>> svg.find('00061')
-        1780
+        1795
         >>> svg.find('has been modified')
         54
 
@@ -549,24 +549,16 @@ class KanjiColorizer:
         Add a grid to the svg, depending on the setting the program is run with.
         The grid does not need rescaling.
 
-        >>> svg = '<svg  width="109" height="109" viewBox="0 0 109 109">'
+        >>> svg = '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">\\n'
         >>> kc = KanjiColorizer('--grid 4')
         >>> kc._add_grid(svg)
-        '<svg  width="109" height="109" viewBox="0 0 109 109">\n
-        <g id="kvg:grid" stroke="grey">\n
-        \t<path id="kvg:grid-4h" d="M0,163.5H327"/>\n
-        \t<path id="kvg:grid-4v" d="M163.5,0V327"/>\n
-        </g>'
-        >>> svg = '<svg  width="109" height="109" viewBox="0 0 109 109">'
+        '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">\\n<g id="kvg:grid" stroke="grey">\\n\\t<path id="kvg:grid-4h" d="M0,163.5H327"/>\\n\\t<path id="kvg:grid-4v" d="M163.5,0V327"/>\\n</g>\\n'
+        >>> svg = '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">\\n'
         >>> kc = KanjiColorizer('--grid diag --image-size 109')
         >>> kc._add_grid(svg)
-        '<svg  width="109" height="109" viewBox="0 0 109 109">\n
-        <g id="kvg:grid" stroke="grey">\n
-        \t<path id="kvg:grid-d1" d="M0,0L109,109"/>\n'
-        \t<path id="kvg:grid-d1" d="M0,109L109,0"/>\n'
-        </g>'
+        '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">\\n<g id="kvg:grid" stroke="grey">\\n\\t<path id="kvg:grid-d1" d="M0,0L109,109"/>\\n\\t<path id="kvg:grid-d1" d="M0,109L109,0"/>\\n</g>\\n'
         """
-        grid = '\n<g id="kvg:grid" stroke="grey">\n'
+        grid = '<g id="kvg:grid" stroke="grey">\n'
         if "4" in self.settings.grid or "8" in self.settings.grid:
             grid = grid + '\t<path id="kvg:grid-4h" d="M0,' + str(self.settings.image_size/2) + 'H' + str(self.settings.image_size) + '"/>\n'
             grid = grid + '\t<path id="kvg:grid-4v" d="M' + str(self.settings.image_size/2) + ',0V' + str(self.settings.image_size) + '"/>\n'
@@ -579,7 +571,7 @@ class KanjiColorizer:
             grid = grid + '\t<path id="kvg:grid-d1" d="M0,0L' + str(self.settings.image_size) + ',' + str(self.settings.image_size) + '"/>\n'
             grid = grid + '\t<path id="kvg:grid-d1" d="M0,' + str(self.settings.image_size) + 'L' + str(self.settings.image_size) + ',0"/>\n'
         grid = grid + '</g>\n'
-        place_after = '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">'
+        place_after = '<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">\n'
         return svg.replace(place_after, place_after + grid)
 
     def _comment_copyright(self, svg):

--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -286,7 +286,7 @@ class KanjiColorizer:
         self._parser.add_argument('--grid', default='none', type=str,
                     choices=['none', '4', '8', 'diag', 'diag4', 'diag8'],
                     help='none: no grid is drawn. 4: a 2x2 grid is drawn. '
-                        '8; a 4x4 grid is drawn. diag: diagonals are drawn. '
+                        '8: a 4x4 grid is drawn. diag: diagonals are drawn. '
                         'diag4: a 2x2 grid with diagonals is drawn. '
                         'diag8: a 4x4 grid with diagonals is drawn. '
                         '(default: ' '%(default)s)')

--- a/test/default_results/kanji-colorize-contrast/a.svg
+++ b/test/default_results/kanji-colorize-contrast/a.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: 327
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/test/default_results/kanji-colorize-contrast/あ.svg
+++ b/test/default_results/kanji-colorize-contrast/あ.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: none
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/test/default_results/kanji-colorize-contrast/漢.svg
+++ b/test/default_results/kanji-colorize-contrast/漢.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: none
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/test/default_results/kanji-colorize-spectrum/a.svg
+++ b/test/default_results/kanji-colorize-spectrum/a.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: none
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/test/default_results/kanji-colorize-spectrum/あ.svg
+++ b/test/default_results/kanji-colorize-spectrum/あ.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: none
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:

--- a/test/default_results/kanji-colorize-spectrum/漢.svg
+++ b/test/default_results/kanji-colorize-spectrum/漢.svg
@@ -7,6 +7,7 @@ settings:
     saturation: 0.95
     value: 0.75
     image_size: 327
+    grid: none
 It remains under a Creative Commons-Attribution-Share Alike 3.0 License.
 
 The original SVG has the following copyright:


### PR DESCRIPTION
Hi! I tried to implement a feature that I think could be useful: an option to draw a grid under the character.

At first, I added the setting "grid" to the `_parser`. The options are:
* "none": no grid (the default)
* "4": a 2x2 grid
* "8": a 4x4 grid
* "diag": a diagonal grid
* "diag4": a 2x2 grid with diagonals
* "diag8": a 4x4 grid with diagonals

I am not very creative: if you have better ideas for the names of the options let me know.

Then I added a function `_add_grid` (only called if `grid` is not "none") which adds to the svg a group `<g id="kvg:grid" stroke="grey">` containing the needed paths in it. If you wish to change the id or the color, please let me know.

The tests I have written pass, and I modified the `default_results` files to reflect the fact that the "grid" option is added to the svg copyright notice so that also previous tests are ok (except one that was also failing before the changes).

Finally, I have also added the option to the Anki add-on, defaulting to "none".

I have attached an [example](https://github.com/cayennes/kanji-colorize/files/6326263/colorized-kanji.zip) of the generated images. Let me know if you think I should add or change anything!
