### PR TITLE
kanji_colorizer: Support multiple destinations.

### DIFF
--- a/anki/config.md
+++ b/anki/config.md
@@ -7,7 +7,7 @@
 * `group-mode`: Somewhat buggy option to color groups of kanji instead of strokes. (default: `false`)
 * `model`: name of the model containing kanji and diagram fields
 * `src-field`: name of the field that contains the kanji
-* `dst-field`: name of the field to save diagram to
+* `dst-field`: name of the field to save diagram to. Can be an array of names, in which case one diagram will be written to each destination, and the leftover characters will be written to the last destination.
 * `diagrammed-characters`: which characters from the source field to produce diagrams for:
     * `all`: all characters
     * `kanji`: only kanji, not kana or anything else

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Paver==1.2.2
 mock==1.0.1
-pytest==2.6.1
+pytest==6.2.5


### PR DESCRIPTION
If there are more characters than destinations, write all the leftover
characters to the last destination. This way, the current behavior is
preserved.
