### PR TITLE
KanjiSVG __init__ doctest: don't expect fully qualified exception

### DIFF
--- a/kanjicolorizer/colorizer.py
+++ b/kanjicolorizer/colorizer.py
@@ -102,7 +102,7 @@ class KanjiVG(object):
         >>> k = KanjiVG('Л')
         Traceback (most recent call last):
             ...
-        kanjicolorizer.colorizer.InvalidCharacterError: ('\\u041b', '')
+        InvalidCharacterError: ('\\u041b', '')
 
         '''
         self.character = character


### PR DESCRIPTION
As far as I've been able to check online this is the proper way to check it, but as I'm not a python programmer I don't how to set up the environment so the fully qualified exception comes out instead to test it will pass on that scenario.
This at least makes the test pass on my current setup.